### PR TITLE
fix desktop nav issue

### DIFF
--- a/css/components/Navigation/mobile.css
+++ b/css/components/Navigation/mobile.css
@@ -11,7 +11,7 @@
   }
 
   .navbar-sm > .badge-btn,
-  .navbar-md-container .navbar-btn-log {
+  .navbar-sm .navbar-btn-log {
     display: none;
   }
 

--- a/index.html
+++ b/index.html
@@ -958,7 +958,7 @@
             </div>
           </nav>
 
-          <div class="navbar-md-container">
+          <div class="navbar-md-container navbar-sm">
             <form class="navbar-form">
               <input type="text" placeholder="search for product" />
               <button type="submit">


### PR DESCRIPTION
Description: The log-in button was not getting `display: none` for the desktop.

Before,
![image](https://user-images.githubusercontent.com/56081584/155170599-dbd183ad-1d48-46ba-bf21-fdda31d261df.png)

After,
![image](https://user-images.githubusercontent.com/56081584/155170640-30aa7c1b-2da2-4138-95ac-989c59918f76.png)

Please review this PR, and give your feedback.